### PR TITLE
Remove generic RedisClient.get extension

### DIFF
--- a/Sources/RedisKit/RedisClient+Codable.swift
+++ b/Sources/RedisKit/RedisClient+Codable.swift
@@ -2,24 +2,9 @@ import RediStack
 import AsyncKit
 import Foundation
 
+// MARK: JSON
+
 extension RedisClient {
-    /// Gets key as a `RedisDataConvertible` type.
-    public func get<D>(_ key: String, as type: D.Type) -> EventLoopFuture<D?> where D: RESPValueConvertible {
-        return get(key).map { value in
-            guard let value = value else {
-                return nil
-            }
-            if value.isEmpty {
-                return nil
-            } else {
-                let value = RESPValue(value)
-                return D(fromRESP: value)
-            }
-        }
-    }
-
-    // MARK: JSON
-
     /// Gets key as a decodable type.
     public func get<D>(_ key: String, asJSON type: D.Type) -> EventLoopFuture<D?> where D: Decodable {
         return get(key, as: Data.self).flatMapThrowing { data in


### PR DESCRIPTION
Motivation:

RediStack now provides its own implementation of a generic overload of `get`, which is more correct than RedisKit's.

Modifications:

- Remove RedisClient.get generic extension for `RESPValueConvertible` types

Result:

Duplicate symbols should no longer be provided from both RediStack and RedisKit