### PR TITLE
Fix Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,18 +11,18 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://gitlab.com/mordil/swift-redi-stack.git", from: "1.0.0-alpha.7"),
+        .package(name: "redi-stack", url: "https://gitlab.com/mordil/swift-redi-stack.git", from: "1.0.0-alpha.7"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0-rc"),
     ],
     targets: [
         .target(name: "RedisKit", dependencies: [
             .product(name: "AsyncKit", package: "async-kit"),
-            .product(name: "RediStack", package: "swift-redi-stack"),
+            .product(name: "RediStack", package: "redi-stack"),
             .product(name: "Logging", package: "swift-log"),
         ]),
         .testTarget(name: "RedisKitTests", dependencies: [
             .target(name: "RedisKit"),
-            .product(name: "RediStackTestUtils", package: "swift-redi-stack"),
+            .product(name: "RediStackTestUtils", package: "redi-stack"),
         ]),
     ]
 )


### PR DESCRIPTION
When building I get the error: 
'redis-kit' /home/sam/Schreibtisch/v4blog/.build/checkouts/redis-kit: error: product dependency 'RediStack' in package 'swift-redi-stack' not found

This pr should fix it.